### PR TITLE
[WIP] Add global_conf_US915_TTN.json

### DIFF
--- a/global_conf_US915_TTN.json
+++ b/global_conf_US915_TTN.json
@@ -1,0 +1,215 @@
+{
+    "SX1301_conf": {
+        "lorawan_public": true,
+        "clksrc": 1, /* radio_1 provides clock to concentrator */
+        "antenna_gain": 0, /* antenna gain, in dBi */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 904300000,
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "tx_freq_min": 923000000,
+            "tx_freq_max": 928000000
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 923000000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 903.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 904.1 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 904.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 904.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 904.7 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -300000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 904.9 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -100000
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 905.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 100000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 905.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 500kHz, SF8, 904.6 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 500000,
+            "spread_factor": 8
+        },
+        "chan_FSK": {
+            /* FSK 100kbps channel, 903.0 MHz */
+            "enable": false,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 250000,
+            "datarate": 100000
+        },
+"tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 0
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 0
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 12,
+            "rf_power": 0,
+            "dig_gain": 0
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 1,
+            "mix_gain": 8,
+            "rf_power": 3,
+            "dig_gain": 0
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 0
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 0
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 11,
+            "dig_gain": 0
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 15,
+            "rf_power": 13,
+            "dig_gain": 0
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 2,
+            "mix_gain": 10,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 16,
+            "dig_gain": 0
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 3,
+            "mix_gain": 9,
+            "rf_power": 20,
+            "dig_gain": 0
+        },
+        "tx_lut_12": {
+            /* TX gain table, index 12 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 23,
+            "dig_gain": 0
+        },
+        "tx_lut_13": {
+            /* TX gain table, index 13 */
+            "pa_gain": 3,
+            "mix_gain": 11,
+            "rf_power": 25,
+            "dig_gain": 0
+        },
+        "tx_lut_14": {
+            /* TX gain table, index 14 */
+            "pa_gain": 3,
+            "mix_gain": 12,
+            "rf_power": 26,
+            "dig_gain": 0
+        },
+        "tx_lut_15": {
+            /* TX gain table, index 15 */
+            "pa_gain": 3,
+            "mix_gain": 14,
+            "rf_power": 27,
+            "dig_gain": 0
+        }
+    },
+
+    "gateway_conf": {
+        "gateway_ID": "3537323928004f00",
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "router.us.thethings.network",
+        "serv_port_up": 1700,
+        "serv_port_down": 1700,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false
+    }
+}


### PR DESCRIPTION
The `global_conf_US915.json` file in the Heltec distribution is good for subband 1 (ch 0\~7/64) in the US. But The Things Network and myDevices use subband 2 (ch 8\~15/65). Let's add a `global_conf_US915_TTN.json` that's set up for US TTN operation directly.

This pull-request is marked as "work-in-progress" because:

1. I've not fully tested -- I've confirmed that packets are correctly received and logged using `util_pkt_logger` (using USB mode on Ubuntu 16.04LTS), but I've not yet registered the gateway with the network.
2. I wonder if we might also want to remove the non-standard `/*` .. `*/` json comments. The Things network uses `"desc": "commentary"` as standard json syntax.
3. I'm not sure whether the change in the base RSSI is right for the Heltec hardware; I suspect maybe not.

The reference for the setup was taken from The Things Network [gateway-conf/US-global_conf.json](https://github.com/TheThingsNetwork/gateway-conf/blob/master/US-global_conf.json).